### PR TITLE
Fix DB initialization and gradle path

### DIFF
--- a/lib/core/admob_config.dart
+++ b/lib/core/admob_config.dart
@@ -75,8 +75,8 @@ class AdMobConfig {
         return false;
       }
 
-      // app/build.gradle 파일 경로
-      final gradlePath = 'android/app/build.gradle';
+      // app/build.gradle 파일 경로 (Kotlin DSL 사용)
+      final gradlePath = 'android/app/build.gradle.kts';
 
       // 파일 읽기
       final File gradleFile = File(gradlePath);

--- a/lib/core/database_helper.dart
+++ b/lib/core/database_helper.dart
@@ -9,8 +9,17 @@ class DatabaseHelper {
 
   Future<Database> get database async {
     if (_database != null) return _database!;
-    // _database = await _initDatabase();
+    _database = await _initDatabase();
     return _database!;
+  }
+
+  Future<Database> _initDatabase() async {
+    final dbPath = await getDatabasesPath();
+    final path = '$dbPath/app_database.db';
+    return openDatabase(
+      path,
+      version: 1,
+    );
   }
 
   // Future<Database> _initDatabase() async {


### PR DESCRIPTION
## Summary
- fix uninitialized database instance in `DatabaseHelper`
- correct gradle file path for Kotlin DSL projects

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841212f1a2c8328b945711acd325d44